### PR TITLE
Phase 0a follow-up: seven per-layer SPAs + local-run README: https://github.com/metanorma/metanorma-model-iso/issues/115

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,20 +32,23 @@ jobs:
           bundler-cache: true
 
       - name: Fix include paths in rnc files
+        run: ruby scripts/flatten-include-files.rb
+
+      - name: Build seven per-layer SPAs
         run: |
-          ruby scripts/flatten-include-files.rb
+          mkdir -p _site/spa
+          for s in basicdoc biblio biblio-standoc biblio-presentation relaton-iso isodoc isodoc-presentation; do
+            echo "::group::Build $s"
+            bundle exec lutaml-xsd build from-config doc-build/configs/$s.yml --output _site/spa/$s.lxr
+            bundle exec lutaml-xsd spa _site/spa/$s.lxr --mode inlined --output _site/spa/$s.html
+            rm -f _site/spa/$s.lxr
+            echo "::endgroup::"
+          done
 
-      - name: Build LXR package
-        run: bundle exec lutaml-xsd build from-config build-config-small.yml --output metanorma-model-iso.lxr
-
-      - name: Generate SPA documentation
-        run: bundle exec lutaml-xsd spa metanorma-model-iso.lxr --mode inlined --output metanorma-model-iso.html
-
-      - name: Prepare artifact
+      - name: Prepare site index and assets
         run: |
-          mkdir -p _site
-          cp metanorma-model-iso.html _site/index.html
-          cp -r images _site/
+          cp doc-build/index.html _site/index.html
+          if [ -d images ]; then cp -r images _site/; fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 */jing-trang
 
 .rubocop-https--*
+
+doc-build/out/
+_site/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PNG := $(patsubst views/%.lutaml,images/%.png,$(SRC))
 all: $(PNG)
 
 images/%.png: views/%.lutaml
-	lutaml -t png -o $@ $<
+	lutaml lml generate $< -o $@
 
 views/%.lutaml: models/%.wsd | views
 	lutaml-wsd2uml $< > $@

--- a/doc-build/README.adoc
+++ b/doc-build/README.adoc
@@ -1,0 +1,121 @@
+= Building the schema-documentation SPAs locally
+
+This directory carries the per-layer build configuration for the schema-documentation SPAs published from this repository. The pipeline is `RNC -> lutaml-xsd builds an LXR package -> lutaml-xsd builds an SPA for the LXR package`; CI publishes seven SPAs (one per conceptual schema layer) to GitHub Pages via `.github/workflows/deploy.yml`. This README documents the local-development equivalent of the CI build, so a contributor can iterate on the grammars or the configs without waiting for a push to `main`.
+
+Full programme plan: https://github.com/metanorma/metanorma-model-iso/blob/main/plans/Schema-documentation-master-plan.md.
+
+== Prerequisites
+
+* Ruby 4.0 (matching CI; older 3.x lines have not been validated).
+* Bundler.
+* Git, with submodule access — the grammars depend on several sibling submodules (`grammars/basicdoc-models/`, `grammars/bib-models/`, `grammars/metanorma-requirements-models/`, the `grammars/relaton-models/` family).
+
+== One-time setup
+
+. Clone the repo with submodules:
++
+[source,sh]
+----
+git clone --recurse-submodules https://github.com/metanorma/metanorma-model-iso.git
+cd metanorma-model-iso
+----
++
+If you already cloned without submodules, run `git submodule update --init --recursive`.
+
+. Install Ruby dependencies:
++
+[source,sh]
+----
+bundle install
+----
+
+. Flatten the submodule RNC files into the top-level `grammars/` directory. The submodules carry their RNC sources at deeper paths (e.g. `grammars/basicdoc-models/grammars/basicdoc.rnc`); the flatten script copies them up so `lutaml-xsd`'s `include "basicdoc.rnc"` resolves without path traversal:
++
+[source,sh]
+----
+ruby scripts/flatten-include-files.rb
+----
++
+The script is idempotent — re-running is safe. CI runs it once per build. Re-run locally whenever a submodule pull brings in changed RNC sources.
+
+== Building one SPA
+
+The seven per-layer configs live in `doc-build/configs/`. Pick one and run the two-step pipeline:
+
+[source,sh]
+----
+SCHEMA=isodoc                       # or basicdoc / biblio / biblio-standoc / biblio-presentation / relaton-iso / isodoc-presentation
+mkdir -p doc-build/out
+bundle exec lutaml-xsd build from-config doc-build/configs/$SCHEMA.yml \
+  --output doc-build/out/$SCHEMA.lxr
+bundle exec lutaml-xsd spa doc-build/out/$SCHEMA.lxr \
+  --mode inlined \
+  --output doc-build/out/$SCHEMA.html
+open doc-build/out/$SCHEMA.html     # or xdg-open on Linux
+----
+
+The `inlined` mode bundles the Vue SPA assets into a single self-contained HTML file (works with `file://`, no HTTP server required). The output is typically 200-300 KB per schema.
+
+== Building all seven SPAs
+
+[source,sh]
+----
+mkdir -p doc-build/out
+for s in basicdoc biblio biblio-standoc biblio-presentation relaton-iso isodoc isodoc-presentation; do
+  bundle exec lutaml-xsd build from-config doc-build/configs/$s.yml \
+    --output doc-build/out/$s.lxr
+  bundle exec lutaml-xsd spa doc-build/out/$s.lxr \
+    --mode inlined \
+    --output doc-build/out/$s.html
+done
+cp doc-build/index.html doc-build/out/index.html
+open doc-build/out/index.html
+----
+
+The local `index.html` mirrors what CI publishes at the gh-pages root: a landing page linking to all seven per-layer SPAs.
+
+== The seven schema layers
+
+[cols="1,3", options="header"]
+|===
+| Config | Documents
+
+| `doc-build/configs/basicdoc.yml`
+| BasicDocument foundation. Standalone root.
+
+| `doc-build/configs/biblio.yml`
+| Base Relaton citation model. Includes `basicdoc.rnc` as a dependency because `biblio.rnc` references `BasicBlockNoId` from basicdoc without an `include` directive — the config-level listing makes the cross-grammar reference resolve cleanly.
+
+| `doc-build/configs/biblio-standoc.yml`
+| biblio expanded to document metadata (the `bibdata` shape isodoc consumes). Lists basicdoc + biblio + biblio-standoc as the layered prerequisites.
+
+| `doc-build/configs/biblio-presentation.yml`
+| Presentation form of bibliographic metadata. Lists basicdoc + biblio + biblio-presentation.
+
+| `doc-build/configs/relaton-iso.yml`
+| relaton-flavour exemplar (ISO). Built from `relaton-iso-compile.rnc` which already composes basicdoc + relaton-iso. The wider `relaton-*` flavour family follows the same pattern and gets added in parallel as the documentation effort expands.
+
+| `doc-build/configs/isodoc.yml`
+| StanDoc semantic schema. Built from `isodoc-compile.rnc` which composes biblio-standoc + isodoc.
+
+| `doc-build/configs/isodoc-presentation.yml`
+| Presentation form of isodoc. Built from `isodoc-presentation-compile.rnc` which composes biblio-presentation + isodoc-presentation.
+|===
+
+== Adding documentation comments
+
+The `##` doc-comment convention used by the SPAs is documented at `documentation/RNC-COMMENT-CONVENTIONS.adoc`. Edits to those comments in `grammars/*.rnc` show up in the next SPA build with no other action needed.
+
+== Troubleshooting
+
+* **`Cannot find file basicdoc.rnc`** in the build step — the flatten script hasn't been run, or the submodules aren't up to date. Re-run `git submodule update --init --recursive && ruby scripts/flatten-include-files.rb`.
+* **Unresolved pattern `BasicBlockNoId`** in the biblio / biblio-standoc / biblio-presentation builds — the prerequisite-list ordering in the config matters; basicdoc must precede biblio.
+* **Empty or sparse SPA** for a layer — the grammar likely has few `##` doc-comments. The documentation density is uneven across the seven layers; the small flavour wrappers carry fewer comments than the big core grammars.
+* **CI succeeded but local fails** (or vice versa) — check the Ruby version (`ruby --version` should report `4.0.x` to match CI). The `bundler-cache` step in CI also pulls a fresh `Gemfile.lock` — locally, `bundle update lutaml-xsd` if the gem moved.
+
+== Files in this directory
+
+* `configs/` — per-layer build configs (seven YAML files, one per schema layer).
+* `index.html` — the gh-pages landing page copied to `_site/index.html` at deploy time.
+* `out/` — local build outputs (`.lxr` and `.html` files). Not committed; in `.gitignore`.
+* `README.adoc` — this file.

--- a/doc-build/configs/basicdoc.yml
+++ b/doc-build/configs/basicdoc.yml
@@ -2,4 +2,4 @@
 # Built into doc-build/out/basicdoc.html as a stand-alone SPA.
 
 files:
-  - grammars/basicdoc.rnc
+  - ../../grammars/basicdoc.rnc

--- a/doc-build/configs/basicdoc.yml
+++ b/doc-build/configs/basicdoc.yml
@@ -1,0 +1,5 @@
+# Per-layer documentation build config for basicdoc
+# Built into doc-build/out/basicdoc.html as a stand-alone SPA.
+
+files:
+  - grammars/basicdoc.rnc

--- a/doc-build/configs/biblio-presentation.yml
+++ b/doc-build/configs/biblio-presentation.yml
@@ -1,0 +1,8 @@
+# Per-layer documentation build config for biblio-presentation (presentation
+# form of metadata). Dependencies listed for cross-grammar reference
+# resolution.
+
+files:
+  - grammars/basicdoc.rnc
+  - grammars/biblio.rnc
+  - grammars/biblio-presentation.rnc

--- a/doc-build/configs/biblio-presentation.yml
+++ b/doc-build/configs/biblio-presentation.yml
@@ -3,6 +3,6 @@
 # resolution.
 
 files:
-  - grammars/basicdoc.rnc
-  - grammars/biblio.rnc
-  - grammars/biblio-presentation.rnc
+  - ../../grammars/basicdoc.rnc
+  - ../../grammars/biblio.rnc
+  - ../../grammars/biblio-presentation.rnc

--- a/doc-build/configs/biblio-standoc.yml
+++ b/doc-build/configs/biblio-standoc.yml
@@ -3,6 +3,6 @@
 # resolution.
 
 files:
-  - grammars/basicdoc.rnc
-  - grammars/biblio.rnc
-  - grammars/biblio-standoc.rnc
+  - ../../grammars/basicdoc.rnc
+  - ../../grammars/biblio.rnc
+  - ../../grammars/biblio-standoc.rnc

--- a/doc-build/configs/biblio-standoc.yml
+++ b/doc-build/configs/biblio-standoc.yml
@@ -1,0 +1,8 @@
+# Per-layer documentation build config for biblio-standoc (document metadata
+# layer extending biblio). Dependencies listed for cross-grammar reference
+# resolution.
+
+files:
+  - grammars/basicdoc.rnc
+  - grammars/biblio.rnc
+  - grammars/biblio-standoc.rnc

--- a/doc-build/configs/biblio.yml
+++ b/doc-build/configs/biblio.yml
@@ -5,5 +5,5 @@
 # referenced types.
 
 files:
-  - grammars/basicdoc.rnc
-  - grammars/biblio.rnc
+  - ../../grammars/basicdoc.rnc
+  - ../../grammars/biblio.rnc

--- a/doc-build/configs/biblio.yml
+++ b/doc-build/configs/biblio.yml
@@ -1,0 +1,9 @@
+# Per-layer documentation build config for biblio (base citation model).
+# biblio.rnc references BasicBlockNoId from basicdoc.rnc without including it,
+# so basicdoc.rnc is listed first as a dependency for cross-grammar reference
+# resolution. The SPA primary target is biblio; basicdoc elements appear as
+# referenced types.
+
+files:
+  - grammars/basicdoc.rnc
+  - grammars/biblio.rnc

--- a/doc-build/configs/isodoc-presentation.yml
+++ b/doc-build/configs/isodoc-presentation.yml
@@ -1,0 +1,5 @@
+# Per-layer documentation build config for isodoc-presentation
+# Built into doc-build/out/isodoc-presentation.html as a stand-alone SPA.
+
+files:
+  - grammars/isodoc-presentation-compile.rnc

--- a/doc-build/configs/isodoc-presentation.yml
+++ b/doc-build/configs/isodoc-presentation.yml
@@ -2,4 +2,4 @@
 # Built into doc-build/out/isodoc-presentation.html as a stand-alone SPA.
 
 files:
-  - grammars/isodoc-presentation-compile.rnc
+  - ../../grammars/isodoc-presentation-compile.rnc

--- a/doc-build/configs/isodoc.yml
+++ b/doc-build/configs/isodoc.yml
@@ -2,4 +2,4 @@
 # Built into doc-build/out/isodoc.html as a stand-alone SPA.
 
 files:
-  - grammars/isodoc-compile.rnc
+  - ../../grammars/isodoc-compile.rnc

--- a/doc-build/configs/isodoc.yml
+++ b/doc-build/configs/isodoc.yml
@@ -1,0 +1,5 @@
+# Per-layer documentation build config for isodoc
+# Built into doc-build/out/isodoc.html as a stand-alone SPA.
+
+files:
+  - grammars/isodoc-compile.rnc

--- a/doc-build/configs/relaton-iso.yml
+++ b/doc-build/configs/relaton-iso.yml
@@ -1,0 +1,5 @@
+# Per-layer documentation build config for relaton-iso
+# Built into doc-build/out/relaton-iso.html as a stand-alone SPA.
+
+files:
+  - grammars/relaton-iso-compile.rnc

--- a/doc-build/configs/relaton-iso.yml
+++ b/doc-build/configs/relaton-iso.yml
@@ -2,4 +2,4 @@
 # Built into doc-build/out/relaton-iso.html as a stand-alone SPA.
 
 files:
-  - grammars/relaton-iso-compile.rnc
+  - ../../grammars/relaton-iso-compile.rnc

--- a/doc-build/index.html
+++ b/doc-build/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Metanorma model-iso — schema documentation</title>
+<style>
+  body { font: 14px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 760px; margin: 3em auto; padding: 0 1em; color: #1a1a1a; }
+  h1 { font-size: 1.6em; margin-bottom: 0.2em; }
+  .lede { color: #555; margin-top: 0; }
+  h2 { font-size: 1.15em; margin-top: 2em; border-bottom: 1px solid #ddd; padding-bottom: 0.2em; }
+  ul { list-style: none; padding-left: 0; }
+  li { margin: 0.6em 0; }
+  li a { font-weight: 600; text-decoration: none; color: #1259a5; }
+  li a:hover { text-decoration: underline; }
+  li .desc { display: block; color: #555; font-weight: normal; }
+  footer { margin-top: 3em; color: #888; font-size: 0.85em; border-top: 1px solid #eee; padding-top: 1em; }
+  footer a { color: #1259a5; }
+</style>
+</head>
+<body>
+<h1>Metanorma model-iso — schema documentation</h1>
+<p class="lede">Per-schema SPAs generated from the RNC grammars in this repo. Each SPA documents a single conceptual layer; cross-layer references resolve transitively at SPA-composition time per the bidirectional cross-linking architecture.</p>
+
+<h2>Document-content layers</h2>
+<ul>
+  <li><a href="spa/basicdoc.html">basicdoc</a><span class="desc">BasicDocument foundation — paragraph-level constructs, inline elements, common attributes.</span></li>
+  <li><a href="spa/isodoc.html">isodoc</a><span class="desc">StanDoc semantic schema — standardisation document structure on top of basicdoc, includes the requirements model (<code>reqt.rnc</code>) and document metadata (<code>biblio-standoc.rnc</code>).</span></li>
+  <li><a href="spa/isodoc-presentation.html">isodoc-presentation</a><span class="desc">Presentation form of isodoc — autonumbering, internationalisation, cross-reference labelling, rendering-suited element variants.</span></li>
+</ul>
+
+<h2>Bibliographic-metadata layers</h2>
+<ul>
+  <li><a href="spa/biblio.html">biblio</a><span class="desc">Base Relaton citation model. References basicdoc-defined text-block patterns; the SPA carries basicdoc dependencies transitively.</span></li>
+  <li><a href="spa/biblio-standoc.html">biblio-standoc</a><span class="desc">biblio expanded for standardisation-document metadata (the <code>bibdata</code> shape used by isodoc).</span></li>
+  <li><a href="spa/biblio-presentation.html">biblio-presentation</a><span class="desc">Presentation form of bibliographic metadata.</span></li>
+  <li><a href="spa/relaton-iso.html">relaton-iso</a><span class="desc">Relaton flavour-specific metadata for ISO citations (ISO TC/SC structure, document-stage taxonomies). One of the <code>relaton-*</code> flavour family — current and first-class; ISO is the exemplar, other flavours follow the same pattern.</span></li>
+</ul>
+
+<footer>
+Schema documentation for <a href="https://github.com/metanorma/metanorma-model-iso">metanorma/metanorma-model-iso</a>. The full programme plan is at <a href="https://github.com/metanorma/metanorma-model-iso/blob/main/plans/Schema-documentation-master-plan.md">plans/Schema-documentation-master-plan.md</a>; per-phase issues track execution.
+</footer>
+</body>
+</html>


### PR DESCRIPTION
Part of https://github.com/metanorma/metanorma-model-iso/issues/115. Programme parent: https://github.com/metanorma/standoc-models/issues/30.

Full plan: <https://github.com/metanorma/metanorma-model-iso/blob/main/plans/Schema-documentation-master-plan.md#phase-0a>

Fills the three gaps left by metanorma/metanorma-model-iso#125 against the Phase 0a ask:

## What this PR adds

### 1. Seven per-layer SPAs instead of one combined SPA

metanorma/metanorma-model-iso#125 built a single combined SPA from `build-config-small.yml` (all seven schema entry points fused into one LXR package). The plan's per-layer cross-link contract calls for **one SPA per conceptual schema layer**, so a reader landing on the biblio panel sees biblio content scoped to its own non-terminals, with cross-grammar references rendering as outbound links rather than as in-SPA navigation that blurs the layer.

This PR adds `doc-build/configs/` with seven per-layer configs:

- `basicdoc.yml` — standalone root.
- `biblio.yml` — lists `basicdoc.rnc` as a prerequisite (cross-grammar reference resolution for `BasicBlockNoId`).
- `biblio-standoc.yml` — basicdoc + biblio + biblio-standoc.
- `biblio-presentation.yml` — basicdoc + biblio + biblio-presentation.
- `relaton-iso.yml` — built from `relaton-iso-compile.rnc` (already wraps basicdoc + relaton-iso). The wider `relaton-*` flavour family follows the same pattern and gets added in parallel as the documentation effort expands.
- `isodoc.yml` — built from `isodoc-compile.rnc`.
- `isodoc-presentation.yml` — built from `isodoc-presentation-compile.rnc`.

### 2. `.github/workflows/deploy.yml` loops over the seven configs

Replaces the single build/spa step pair with a `for` loop that emits seven `.html` files into `_site/spa/`. The existing `build-config-{small,full}.yml` files from metanorma/metanorma-model-iso#125 remain in the tree, unreferenced by the workflow — left in place rather than removed since they may be useful for ad-hoc "single-combined-SPA" debugging.

### 3. Landing page at `_site/index.html`

`doc-build/index.html` is the gh-pages landing page, linking to the seven per-layer SPAs grouped by document-content (basicdoc / isodoc / isodoc-presentation) and bibliographic-metadata (biblio / biblio-standoc / biblio-presentation / relaton-iso) families. Copied into `_site/index.html` at deploy time.

### 4. `doc-build/README.adoc` — how to run the pipeline locally

Documents prerequisites, one-time setup (clone with submodules, `bundle install`, `ruby scripts/flatten-include-files.rb`), the per-schema and all-seven build incantations, the seven-layer table, and troubleshooting notes. This was an explicit Phase 0a deliverable that metanorma/metanorma-model-iso#125 didn't include.

### 5. `.gitignore` additions

Excludes `doc-build/out/` (local build artefacts) and `_site/` (the CI artefact staging dir, in case anyone runs the deploy steps locally).

## What this PR does **not** address (deferred to follow-up)

- **`config.yml` metadata block** — Wa's `build-config-{small,full}.yml` and the per-layer configs in this PR all carry just the `files:` list. The plateau-style metadata block (license / authors / tags / namespace_mappings / appearance / branding) is deferred. Once CI confirms the seven-SPA build works end-to-end, a follow-up adds the metadata to each per-layer config — branding can come later, don't hold up the pipeline now.
- **Resolution of the open question** about whether `lutaml-xsd spa --mode inlined` (Wa's invocation, kept here for consistency) or `lutaml-xsd doc spa --mode vue_inlined` (the plateau exemplar's invocation) is the right form. CI will tell us; either way it's a one-line fix.
- **Cross-grammar reference handling in detail** — Wa's `flatten-include-files.rb` script copies submodule RNC files up to `grammars/`, and the per-layer configs list dependencies explicitly. Whether this composes cleanly or whether lutaml-xsd produces a single big SPA with all listed schemas mixed in rather than scoping to the "primary" target is the open verification question. If the SPA-per-layer-with-prereqs pattern doesn't scope correctly, a follow-up switches to thin doc-only wrappers per the plan's original proposal.

## Plan update following this PR

The plan's "Phasing → Phase 0a" section will be updated direct to `main` (per the plan-only-direct-push rule) to note: (a) issue metanorma/metanorma-model-iso#124 in the issue list, (b) the per-layer-SPA decision (kept; not collapsed to combined), (c) the flatten-script approach to cross-grammar reference handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
