### PR TITLE
Strip RNC 'grammar { ... }' wrapper as workaround for lutaml/rng#19: https://github.com/metanorma/metanorma-model-iso/issues/116

### DIFF
--- a/scripts/flatten-include-files.rb
+++ b/scripts/flatten-include-files.rb
@@ -9,3 +9,32 @@ rnc_files.each do |file|
   dest = "grammars/#{File.basename(file)}"
   FileUtils.cp(file, dest) unless File.exist?(dest)
 end
+
+# ---------------------------------------------------------------------------
+# TODO: REMOVE WHEN lutaml/rng#19 IS FIXED
+# https://github.com/lutaml/rng/issues/19
+#
+# lutaml/rng's RNC parser does not recurse into the standard RelaxNG
+# `grammar { ... }` enclosing block. All real-world metanorma `.rnc` files
+# open with this block, so the SPA documentation pipeline yields schemas
+# with zero types / elements / groups / attributes inside.
+#
+# Workaround: strip the outer `grammar {` ... matching `}` from every
+# top-level `grammars/*.rnc` after flattening. The wrapper is purely
+# syntactic; the content inside is identical to top-level RNC, so this
+# preserves semantics for the documentation pipeline.
+#
+# Once lutaml/rng#19 is fixed and the new gem is in the build's Gemfile
+# resolution, DELETE THIS BLOCK in full.
+# ---------------------------------------------------------------------------
+Dir.glob("grammars/*.rnc").each do |path|
+  src = File.read(path, encoding: "UTF-8")
+  # Match a leading `grammar {` (possibly with whitespace/blank lines before
+  # or after the brace) and its matching closing `}` at the end of file
+  # (possibly followed by trailing whitespace). Only strip when both are
+  # present — leaves include-only roots like relaton-iso-compile.rnc alone.
+  m = src.match(/\Agrammar\s*\{\s*\n?(.*)\n?\}\s*\z/m)
+  next unless m
+
+  File.write(path, m[1])
+end


### PR DESCRIPTION
Part of https://github.com/metanorma/standoc-models/issues/29.

Full plan: <https://github.com/metanorma/metanorma-model-iso/blob/main/plans/Schema-documentation-master-plan.md#phase-0b>

## What this PR does

Extends `scripts/flatten-include-files.rb` with a tactical workaround for a `lutaml/rng` bug surfaced by Phase 0b validation: after flattening submodule `.rnc` files into the top-level `grammars/` directory, the script now also **strips the outer `grammar { ... }` block** from any `grammars/*.rnc` that has one.

## Why

`lutaml/rng`'s RNC parser does not recurse into the standard RelaxNG `grammar { ... }` enclosing block. Six files in `grammars/` open with this block (`basicdoc.rnc`, `biblio.rnc`, `biblio-compile.rnc`, `isodoc.rnc`, `isodoc-collection.rnc`, plus the test fixture `a.rnc`). Without the workaround, the SPA documentation pipeline yields LXR packages with zero types / zero elements per layer — the bug Phase 0b was scoped to surface.

Filed upstream as [lutaml/rng#19](https://github.com/lutaml/rng/issues/19), assigned to `@HassanAkbar`. The bug is real, and per the plan's strong preference ("engine bends, not grammar") we work around it on the build side rather than rewrite the grammars (which would break their RelaxNG validity).

## Semantics preservation

The `grammar { ... }` wrapper is purely syntactic. Content inside is identical to top-level RNC declarations — only the enclosing block changes, not the schema. Stripping is safe for our use case (the documentation pipeline ingests flattened files; the canonical wrapped files in submodules are untouched).

## Removal commitment

The added code carries a prominent `# TODO: REMOVE WHEN lutaml/rng#19 IS FIXED` marker citing the issue URL. The lutaml/rng issue body also explicitly notes the workaround exists in this script and requests its removal when the bug is fixed. The two pointers prevent the workaround from outliving the bug.

## Verification

After this lands, the next CI run produces non-empty SPAs at <https://metanorma.github.io/metanorma-model-iso/>. Per-layer type/element counts should reflect the actual grammar content (`basicdoc` ~50+ elements, `isodoc` ~200+, etc.) rather than zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
