### PR TITLE
Revert PR #127 strip-wrapper workaround — wrong diagnosis: https://github.com/metanorma/metanorma-model-iso/issues/116

### DIFF
--- a/scripts/flatten-include-files.rb
+++ b/scripts/flatten-include-files.rb
@@ -9,32 +9,3 @@ rnc_files.each do |file|
   dest = "grammars/#{File.basename(file)}"
   FileUtils.cp(file, dest) unless File.exist?(dest)
 end
-
-# ---------------------------------------------------------------------------
-# TODO: REMOVE WHEN lutaml/rng#19 IS FIXED
-# https://github.com/lutaml/rng/issues/19
-#
-# lutaml/rng's RNC parser does not recurse into the standard RelaxNG
-# `grammar { ... }` enclosing block. All real-world metanorma `.rnc` files
-# open with this block, so the SPA documentation pipeline yields schemas
-# with zero types / elements / groups / attributes inside.
-#
-# Workaround: strip the outer `grammar {` ... matching `}` from every
-# top-level `grammars/*.rnc` after flattening. The wrapper is purely
-# syntactic; the content inside is identical to top-level RNC, so this
-# preserves semantics for the documentation pipeline.
-#
-# Once lutaml/rng#19 is fixed and the new gem is in the build's Gemfile
-# resolution, DELETE THIS BLOCK in full.
-# ---------------------------------------------------------------------------
-Dir.glob("grammars/*.rnc").each do |path|
-  src = File.read(path, encoding: "UTF-8")
-  # Match a leading `grammar {` (possibly with whitespace/blank lines before
-  # or after the brace) and its matching closing `}` at the end of file
-  # (possibly followed by trailing whitespace). Only strip when both are
-  # present — leaves include-only roots like relaton-iso-compile.rnc alone.
-  m = src.match(/\Agrammar\s*\{\s*\n?(.*)\n?\}\s*\z/m)
-  next unless m
-
-  File.write(path, m[1])
-end


### PR DESCRIPTION
Part of https://github.com/metanorma/standoc-models/issues/29. Reverts the strip-wrapper workaround that was added in metanorma/metanorma-model-iso#127.

## Why revert

The diagnosis behind metanorma/metanorma-model-iso#127 was wrong. CI ran the strip-wrapper script on `main` and the deployed SPAs got **emptier**, not less empty — `relaton-iso` dropped from `2 elements / 1 group` (its `start =` declaration) to `0 / 0 / 0 / 0`.

The real CI log error after the strip:

```
Warning: Failed to parse schema .../grammars/basicdoc.rnc: Failed to match sequence
  (WHITESPACE PREAMBLE? WHITESPACE (
     inner_grammar:GRAMMAR_BLOCK trailing_definitions:(…) /
     top_includes:((INCLUDE_DIRECTIVE WHITESPACE){1,}) … /
     GRAMMAR
   ) WHITESPACE) at line 3 char 18.
```

lutaml/rng's parser accepts three top-level forms: a `grammar { ... }` block, or one or more `include` directives, or a single `GRAMMAR` token. **Bare top-level `define`s without one of those wrappers are not valid RNC.** Stripping the `grammar { ... }` wrapper made `basicdoc.rnc` and the other wrapped files un-parseable. `relaton-iso-compile.rnc` (which includes basicdoc.rnc via top-level `include`) then cascaded to empty because its include target failed to parse.

## What the real bug actually is

The lutaml/rng parser **does** accept the `grammar { ... }` block (no error pre-strip). The bug is downstream: lutaml-xsd's RNC-to-XSD converter parses the grammar block syntactically but doesn't iterate into the inner_grammar's body to extract the `define`s / `element`s / `attribute`s into the LXR package's types/elements/groups/attributes lists. Wrapped files parse successfully and yield empty LXR packages.

The lutaml/rng#19 issue body will be updated to reflect this corrected diagnosis. The workaround in this script was the wrong layer to patch — there's no semantics-preserving transformation we can do to the .rnc files that keeps them parseable AND makes the converter extract content. The fix has to live in the converter.

## After this lands

Site returns to its pre-strip baseline: six layers at 0 elements, `relaton-iso` at 2 elements / 1 group (its top-level `start =`). We wait for lutaml/rng#19 to be reframed against the converter and fixed before the SPAs become useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
