### PR TITLE
Propagate explicit MathML grammar from basicdoc-models v1.3.0

### DIFF
--- a/grammars/copy.sh
+++ b/grammars/copy.sh
@@ -3,12 +3,12 @@ echo "Copying..."
 metanorma_version=`git tag --sort=committerdate | tail -1`
 
 cat isodoc.rng | ruby -pe "\$_.gsub!(/(<grammar[^>]+>)/, %{\\\\1\n<!-- VERSION ${metanorma_version} -->\n}) " > ../../metanorma-standoc/lib/metanorma/validate/isodoc.rng
-cp basicdoc.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-standoc/lib/metanorma/validate
+cp basicdoc.rng metanorma-mathml.rng mathml3*.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-standoc/lib/metanorma/validate
 
 for i in iso iec bsi jis plateau cc ribose generic ieee ogc nist ietf itu iho bipm
 do
   cat isodoc.rng | ruby -pe "\$_.gsub!(/(<grammar[^>]+>)/, %{\\\\1\n<!-- VERSION ${metanorma_version} -->\n}) " > ../../metanorma-$i/lib/metanorma/$i/isodoc.rng
-  cp basicdoc.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-$i/lib/metanorma/$i
+  cp basicdoc.rng metanorma-mathml.rng mathml3*.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-$i/lib/metanorma/$i
 done
 
 for i in iso iec bsi jis cc ribose ieee ogc nist ietf itu iho bipm

--- a/grammars/make.sh
+++ b/grammars/make.sh
@@ -24,6 +24,9 @@ var=`git tag --sort=committerdate | tail -1`
 echo "\"basicdoc-models\": \"$var\"," >> ../../versions.json
 cd ../..
 cp basicdoc-models/grammars/basicdoc.rnc .
+# basicdoc.rnc references the W3C MathML grammar via `external "mathml/..."`;
+# vendor those sources so trang can resolve them at compile time.
+cp -r basicdoc-models/grammars/mathml .
 
 cd metanorma-requirements-models/grammars
 git checkout main && git pull


### PR DESCRIPTION
Refs https://github.com/metanorma/basicdoc-models/issues/35

Propagates the explicit W3C MathML 3 grammar from basicdoc-models v1.3.0 through the universal grammar build:

- bump `basicdoc-models` submodule to v1.3.0 (MathML in `<stem>` via `external "mathml/metanorma-mathml.rnc"`)
- `make.sh`: vendor the `mathml/` sources so trang can resolve the `external` reference
- `copy.sh`: copy the compiled companion grammars (`metanorma-mathml.rng`, `mathml3*.rng`) alongside `basicdoc.rng` to standoc and each flavor (modular set — jing resolves the `externalRef` only with the companions co-located)

Verified locally: trang compiles `basicdoc.rnc` cleanly and jing validates real MathML (incl. `data-metanorma-numberformat`) against the generated wrapper.

Note: the destination gems still need the new companion `.rng` committed — a separate batched grammar-sync, deferred (standoc handled in its own PR).

🤖
