### PR TITLE
Allow custom class attribute on tables

### DIFF
--- a/grammars/isodoc.rnc
+++ b/grammars/isodoc.rnc
@@ -469,6 +469,9 @@ TableAttributes &=
     attribute width { text }?,
     ## CSS style: only background-color, color, border supported
     attribute style { text }?,
+    ## Custom CSS class(es), space-separated, appended to the HTML table
+    ## class (HTML output only). See metanorma/metanorma-pdfa#33
+    attribute class { text }?,
     BlockAttributes
 
 FigureAttributes &=

--- a/grammars/isodoc.rng
+++ b/grammars/isodoc.rng
@@ -842,6 +842,12 @@ titlecase, or lowercase</a:documentation>
         <a:documentation>CSS style: only background-color, color, border supported</a:documentation>
       </attribute>
     </optional>
+    <optional>
+      <attribute name="class">
+        <a:documentation>Custom CSS class(es), space-separated, appended to the HTML table
+class (HTML output only). See metanorma/metanorma-pdfa#33</a:documentation>
+      </attribute>
+    </optional>
     <ref name="BlockAttributes"/>
   </define>
   <define name="FigureAttributes" combine="interleave">


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/33

Add a `class` attribute to `TableAttributes` (in `grammars/isodoc.rnc`, with the regenerated `isodoc.rng`) so a table's custom CSS class survives into Semantic XML and validates. Source half of the table custom-class feature; full narrative on the issue.

🤖
