### PR TITLE
Bump basicdoc-models to MathML 4 grammar; propagate mathml4 in copy.sh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 
 gem "lutaml"
 gem "lutaml-uml"
+gem "lutaml-xsd"

--- a/grammars/copy.sh
+++ b/grammars/copy.sh
@@ -3,12 +3,12 @@ echo "Copying..."
 metanorma_version=`git tag --sort=committerdate | tail -1`
 
 cat isodoc.rng | ruby -pe "\$_.gsub!(/(<grammar[^>]+>)/, %{\\\\1\n<!-- VERSION ${metanorma_version} -->\n}) " > ../../metanorma-standoc/lib/metanorma/validate/isodoc.rng
-cp basicdoc.rng metanorma-mathml.rng mathml3*.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-standoc/lib/metanorma/validate
+cp basicdoc.rng metanorma-mathml.rng mathml4*.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-standoc/lib/metanorma/validate
 
 for i in iso iec bsi jis plateau cc ribose generic ieee ogc nist ietf itu iho bipm
 do
   cat isodoc.rng | ruby -pe "\$_.gsub!(/(<grammar[^>]+>)/, %{\\\\1\n<!-- VERSION ${metanorma_version} -->\n}) " > ../../metanorma-$i/lib/metanorma/$i/isodoc.rng
-  cp basicdoc.rng metanorma-mathml.rng mathml3*.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-$i/lib/metanorma/$i
+  cp basicdoc.rng metanorma-mathml.rng mathml4*.rng reqt.rng biblio.rng biblio-standoc.rng ../../metanorma-$i/lib/metanorma/$i
 done
 
 for i in iso iec bsi jis cc ribose ieee ogc nist ietf itu iho bipm


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-standoc/issues/1212

Submodule bump to the merged MathML 4 vendoring (metanorma/basicdoc-models#40) plus the `mathml3*` → `mathml4*` pattern in `copy.sh`. Regenerated compile artifacts verified byte-identical to metanorma/metanorma-standoc#1214 and the 15-flavour wave.

🤖
