### PR TITLE
isodoc-presentation: rendering channels for term notes/examples and requirements

### DIFF
--- a/grammars/README.adoc
+++ b/grammars/README.adoc
@@ -20,3 +20,36 @@ gem. (The RelaxNG schemas are how documents are actually validated in the gems
 generating Metanorma XML.)
 
 The grammars are generated using `make.sh`. The grammars are validated using `bundle exec ruby test.rb`.
+
+== Presentation XML contract
+
+The grammars `isodoc-presentation.rnc` and `biblio-presentation.rnc` (composed by
+`isodoc-presentation-compile.rnc`) define the Presentation XML overlay on the Semantic
+XML grammar: the semantic document, with rendering channels (`fmt-*` elements) tagged
+alongside the semantic elements they were derived from, and `semx` provenance links
+pointing back to the semantic source of each rendered fragment.
+
+The overlay exists to serve both smart and dumb renderers. A dumb renderer -- one with
+no knowledge of the business rules for rendering concepts, bibliographic sources, or
+autonumbering -- renders entirely from the `fmt-*` channels. A smart renderer may
+ignore the channels and apply the business rules itself to the semantic content.
+
+The contract between the two channels is:
+
+. *Ownership*: `fmt-*` elements are emitter-owned rendering cache. They are generated
+  by the presentation layer and are never authored or edited. Regeneration of the
+  presentation layer overwrites them wholesale.
+. *Precedence*: semantic elements are authoritative for data; `fmt-*` elements are
+  authoritative for rendered text when present. When a consumer derives rendering from
+  semantic content because a channel is absent, it does so as a complete substitution
+  for that rendering -- derived and channel fragments are never mixed within one
+  rendering.
+. *Closure*: the `fmt-*` vocabulary is closed by these grammars. A new rendering
+  channel is added by a grammar change in this repository, in the same change as the
+  emitter that produces it; an emitter must not emit a `fmt-*` element that the
+  grammar does not define.
+. *Coverage*: every renderable semantic element either carries its rendering channel
+  (asset captions via `fmt-name`/`fmt-xref-label`, clause titles via `fmt-title`,
+  requirements via `fmt-provision`, term notes and examples via `fmt-name`/
+  `fmt-xref-label`, deprecations via `fmt-deprecates`, and so on), or is documented
+  in the overlay as passing through to Presentation XML unchanged.

--- a/grammars/isodoc-presentation.rnc
+++ b/grammars/isodoc-presentation.rnc
@@ -246,6 +246,35 @@ term = element term {
     fmt_termsource
 }
 
+## In Presentation XML, term notes are captioned like other assets: fmt-name contains the
+## rendered "Note N to entry" caption (with its delimiters), and fmt-xref-label the default
+## cross-reference text for the note (e.g. "Note 1", or "Clause 2, Note 1" outside its container).
+## The semantic content of the note is retained after the rendering channels.
+termnote =
+  element termnote {
+    RequiredId,
+    NumberingAttributes,
+    BlockAttributes,
+    ## Semantic classification of note
+    attribute type { text }?,
+    fmt-name?,
+    fmt-xref-label*,
+    ## Content of the term note
+    (paragraph-with-footnote | ul | ol | dl | formula)+
+}
+
+## As with termnote: in Presentation XML, term examples are captioned with fmt-name
+## ("EXAMPLE") and cross-referenced via fmt-xref-label, followed by the semantic content.
+termexample =
+  element termexample {
+    RequiredId,
+    BlockAttributes,
+    fmt-name?,
+    fmt-xref-label*,
+    ## Content of the term example
+    ( formula | ul | ol | dl | quote | sourcecode | paragraph-with-footnote | figure )+
+}
+
 DisplayOrder =
   ## The top-level clauses and blocks of the document are numbered in the order in which they should be rendered,
   ## taking floating titles into account.
@@ -870,8 +899,10 @@ ReferencesAttributes &=
 docidentifier &= empty
   
 ## Requirements are labelled with requirement/@class, or according to their element name
-## if requirement/@class is absent, just as with figures
-RequirementType &= fmt-provision
+## if requirement/@class is absent, just as with figures. In Presentation XML, the rendered
+## caption of the requirement is fmt-name, and its default cross-reference text fmt-xref-label
+## (as with other captioned assets); fmt-provision carries the rendered block content.
+RequirementType &= fmt-name?, fmt-xref-label*, fmt-provision
 
 ## Requirements may be rendered arbitrarily depending on the requirements model; in the case of Modspec,
 ## they are rendered as tables. 


### PR DESCRIPTION
## Summary

Closes the grammar-side gaps surfaced by the metanorma-document mapping fixes (metanorma/metanorma-document#48, addressing metanorma-ietf transformer QA and the WS5c completeness audit): the presentation grammar did not declare the rendering channels that the presentation layer actually emits on three carriers, so valid Presentation XML documents failed validation — and conversely, nothing prevented the model layer and the grammar from disagreeing about the `fmt-*` vocabulary.

### Grammar fixes

- **`termnote` / `termexample`** are now redefined in `isodoc-presentation.rnc` with the asset caption channels `fmt-name` (optional) and `fmt-xref-label` (repeatable) preceding the semantic content — matching the emitter's output (`fmt-name` = rendered "Note N to entry" / "EXAMPLE" caption, `fmt-xref-label` = default cross-reference text, incl. the container-scoped variant). Previously the overlay let them pass through with their Semantic shape only, so captioned term notes/examples were grammar-invalid.
- **`RequirementType`** is now augmented with `fmt-name?` and `fmt-xref-label*` alongside the existing `fmt-provision`, so captioned provisions (`fmt-name`, `fmt-xref-label`, semantic children, `fmt-provision`) validate.

### Contract documentation

`grammars/README.adoc` gains a **Presentation XML contract** section recording the design rationale and the going-forward rules for the unified Semantic+Presentation document:

- the overlay exists to serve both **smart renderers** (apply business rules to semantic content themselves) and **dumb renderers** (render entirely from the `fmt-*` channels, with no knowledge of the business rules for rendering concepts, sources, or autonumbering);
- **ownership**: `fmt-*` elements are emitter-owned rendering cache, never authored or edited, overwritten wholesale on regeneration;
- **precedence**: semantic elements are authoritative for data, `fmt-*` for rendered text when present; fallback derivation is a complete substitution, never mixed fragments;
- **closure**: the `fmt-*` vocabulary is closed by these grammars — a new channel requires a grammar change in the same change as the emitter that produces it;
- **coverage**: every renderable semantic element either carries its channel or is documented as passing through unchanged.

### Verification

- `trang` compiles the edited `isodoc-presentation.rnc` cleanly; full chain (`biblio`, `basicdoc`, `reqt`, `isodoc`, presentation overlays, `isodoc-presentation-compile`) rebuilt from current submodules.
- Jing error set against the compiled grammar is byte-for-byte identical to baseline (modulo line numbers) — the pre-existing include-closure artifacts are unchanged and no new errors are introduced.
- Compiled RNG structurally verified: `termnote`/`termexample` defines now reference `fmt-name`/`fmt-xref-label` (absent in baseline); `RequirementType` combines `optional fmt-name`, `zeroOrMore fmt-xref-label`, `fmt-provision` (baseline: `fmt-provision` only).
- CI (`make` workflow) runs the canonical `make.sh` + `test.rb`.

### Related

- Grammar side was already ahead of the model for several reported gaps (all requirement components in `reqt.rnc`, the IETF rfc-attribute channel in `relaton-model-ietf.rnc`, `errormsg` from the grammar epic, `@anchor` universal via `RequiredId`/`OptionalId`) — those required no grammar change; the model-side fixes are in metanorma/metanorma-document#48.
